### PR TITLE
Fix NameError

### DIFF
--- a/brainworkshop.pyw
+++ b/brainworkshop.pyw
@@ -4757,7 +4757,7 @@ def scale_brain(dt):
     brain_graphic.draw()
     if brain_graphic.width < 56:
         mode.shrink_brain = False
-        pyglet.clock.unschedule(shrink_brain)
+        pyglet.clock.unschedule(scale_brain)
         brain_graphic.scale = 1
         brain_graphic.position = (field.center_x - brain_graphic.width//2,
                            field.center_y - brain_graphic.height//2 + 40)


### PR DESCRIPTION
When I tried to run this with Xmonad, I got the following error:

```
Traceback (most recent call last):
  File "./result/bin/brainworkshop", line 4765, in <module>
    scale_brain(scale_to_width(1))
  File "./result/bin/brainworkshop", line 4760, in scale_brain
    pyglet.clock.unschedule(shrink_brain)
NameError: name 'shrink_brain' is not defined
```

This commit fixes the issue (while I'm not familiar with the codebase or pyglet at all, I'm assuming that `shrink_brain` was meant to be `scale_brain`).