### PR TITLE
Fix time today played

### DIFF
--- a/brainworkshop.pyw
+++ b/brainworkshop.pyw
@@ -3328,6 +3328,7 @@ class AnalysisLabel:
         self.label.text = ''.join(str_list)
 
         stats.submit_session(percent, category_percents)
+        stats.parse_statsfile()
 
 # this controls the title of the session history chart.
 class ChartTitleLabel:


### PR DESCRIPTION
Time today played doesn't update after each session, only after total restart of brainworkshop. Fixed by parsing stats file immediately after it was written (once a session ends). The parsing updates the total time played. Fixes #25